### PR TITLE
Adding support for swarm by allowing tls loading from env

### DIFF
--- a/app/clients/swarm_client.rb
+++ b/app/clients/swarm_client.rb
@@ -23,10 +23,10 @@ class SwarmClient
       container.start({ 'PortBindings' => {DEFAULT_PORT => [{"HostPort" => ""}]}})
       ship.update_attribute(:container_id, container.id)
       json = container.json
-      addr = json["NetworkSettings"]["Gateway"]
-      port = json["NetworkSettings"]["Ports"][DEFAULT_PORT].first["HostPort"]
-      ship.update_attribute(:source, addr)
-      ship.update_attribute(:port, port)
+      addr = json["Node"]["Addr"]
+      parts = addr.split(":")
+      ship.update_attribute(:source, parts.first)
+      ship.update_attribute(:port, parts.last)
     end
   end
 

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -1,0 +1,22 @@
+require 'tempfile'
+tmp_dir = "#{Rails.root}/tmp"
+cert_file = Tempfile.new "docker_cert", tmp_dir 
+cert_file.write(ENV["DOCKER_CERT"])
+cert_file.close
+
+key_file = Tempfile.new "docker_key", tmp_dir 
+key_file.write(ENV["DOCKER_KEY"])
+key_file.close
+
+ca_file = Tempfile.new "docker_ca", tmp_dir 
+ca_file.write(ENV["DOCKER_CA"])
+ca_file.close
+
+DOCKER_KEYS=[ca_file, key_file, cert_file]
+
+Docker.options = {
+    client_cert: cert_file.path,
+    client_key: key_file.path,
+    ssl_ca_file: ca_file.path,
+    scheme: 'https'
+}

--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -1,22 +1,25 @@
 require 'tempfile'
-tmp_dir = "#{Rails.root}/tmp"
-cert_file = Tempfile.new "docker_cert", tmp_dir 
-cert_file.write(ENV["DOCKER_CERT"])
-cert_file.close
 
-key_file = Tempfile.new "docker_key", tmp_dir 
-key_file.write(ENV["DOCKER_KEY"])
-key_file.close
+if ENV["DOCKER_CERT"].present?
+  tmp_dir = "#{Rails.root}/tmp"
+  cert_file = Tempfile.new "docker_cert", tmp_dir
+  cert_file.write(ENV["DOCKER_CERT"])
+  cert_file.close
 
-ca_file = Tempfile.new "docker_ca", tmp_dir 
-ca_file.write(ENV["DOCKER_CA"])
-ca_file.close
+  key_file = Tempfile.new "docker_key", tmp_dir
+  key_file.write(ENV["DOCKER_KEY"])
+  key_file.close
 
-DOCKER_KEYS=[ca_file, key_file, cert_file]
+  ca_file = Tempfile.new "docker_ca", tmp_dir
+  ca_file.write(ENV["DOCKER_CA"])
+  ca_file.close
 
-Docker.options = {
+  DOCKER_KEYS=[ca_file, key_file, cert_file]
+
+  Docker.options = {
     client_cert: cert_file.path,
     client_key: key_file.path,
     ssl_ca_file: ca_file.path,
     scheme: 'https'
-}
+  }
+end


### PR DESCRIPTION
SUUUPER simple way to allow docker-than-light to connect to a swarm cluster. Set the tls keys in env, they get written to tmp files and read by the docker client.

(The docker client does not allow the keys to be specified via content not path)

This allows us to configure the docker swarm on heroku
