### PR TITLE
To encode TLS keys in heroku env for use with the docker client

### DIFF
--- a/config/initializers/docker.rb
+++ b/config/initializers/docker.rb
@@ -3,15 +3,15 @@ require 'tempfile'
 if ENV["DOCKER_CERT"].present?
   tmp_dir = "#{Rails.root}/tmp"
   cert_file = Tempfile.new "docker_cert", tmp_dir
-  cert_file.write(ENV["DOCKER_CERT"])
+  cert_file.write(ENV["DOCKER_CERT"].gsub('\\n',"\n"))
   cert_file.close
 
   key_file = Tempfile.new "docker_key", tmp_dir
-  key_file.write(ENV["DOCKER_KEY"])
+  key_file.write(ENV["DOCKER_KEY"].gsub('\\n',"\n"))
   key_file.close
 
   ca_file = Tempfile.new "docker_ca", tmp_dir
-  ca_file.write(ENV["DOCKER_CA"])
+  ca_file.write(ENV["DOCKER_CA"].gsub('\\n',"\n"))
   ca_file.close
 
   DOCKER_KEYS=[ca_file, key_file, cert_file]


### PR DESCRIPTION
we need to use a single line string for heroku env vars. This
change to the initializer covnverts them back to multiline strings
before use
