### PR TITLE
Adding support for log rendering

### DIFF
--- a/app/clients/swarm_client.rb
+++ b/app/clients/swarm_client.rb
@@ -2,9 +2,8 @@ require 'docker'
 class SwarmClient
   class NotFound < StandardError; end
   DEFAULT_PORT = "8080/tcp"
-  def stream_logs(ship)
-    # just dump out logs for now
-    container(ship.container_id).streaming_logs(stdout: true) { |stream, chunk| puts "#{stream}: #{chunk}" }
+  def stream_logs(ship, &block)
+    container(ship.container_id).streaming_logs(stdout: true) { |stream, chunk| yield "#{stream}: #{chunk}" }
   end
 
   def create_ship(ship)

--- a/app/controllers/application/logs_controller.rb
+++ b/app/controllers/application/logs_controller.rb
@@ -1,5 +1,15 @@
 class Application::LogsController < ApplicationController
   def show
     @ship = Ship.find_by!(name: params[:ship_name])
+    self.response_body = Enumerator.new do |y|
+      swarm_client.stream_logs(@ship) do |l|
+        y << l
+      end
+    end
+  end
+
+  private
+  def swarm_client
+    SwarmClient.new
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,11 +11,12 @@ Rails.application.routes.draw do
     get   'sectors'         => 'api#sectors'
     post  'travel/:sector'  => 'api#travel'
 
-    get   'logs/:ship_name' => 'logs#show', as: :ship_log
   end
+
 
   scope module: 'application' do
     resource :dashboard, only: [:show]
+    get 'logs/:ship_name' => 'logs#show', as: :ship_log
   end
 
   root 'website/welcome#index'


### PR DESCRIPTION
This fixes a couple of routes, helper references, and adds chunk rendering
for container logs. Users can refresh the page for update logs.

This is a really simple method we can later replace with a view
backed by a websocket
