### PR TITLE
Supporting API tokens for client auth.

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -25,7 +25,7 @@ class Api::ApiController < Api::ApplicationController
 
   def scan
     @ship = ship
-    if @ship.scan!
+    if @ship.scan! && @ship.sector
       sectors = Sector.where.not(id: @ship.sector.id)
       ships = @ship.sector.ships.where.not(id: @ship.id)
       ships.each do |enemy|
@@ -71,9 +71,5 @@ class Api::ApiController < Api::ApplicationController
 
   def ship_params
     Ship.default_attributes.merge(name: params[:name], image: params[:image])
-  end
-
-  def ship
-    Ship.find_by!(token: authentication_token)
   end
 end

--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,10 +1,22 @@
-class Api::ApplicationController < ApplicationController
+class Api::ApplicationController < ActionController::Base
 	skip_before_filter :verify_authenticity_token
   protect_from_forgery with: :null_session
 
   rescue_from ActiveRecord::RecordNotFound, with: :not_found
-
+  before_action :authenticate
   private
+
+  def authenticate
+    if authentication_token && ship
+      unless ship.source.include? request.remote_ip
+        render nothing: true, status: 404
+      end
+    end
+  end
+
+  def ship
+    Ship.find_by!(token: authentication_token)
+  end
 
   def authentication_token
   	unless request.headers.include?('Authorization')


### PR DESCRIPTION
This change splits out the api controller from the regular
application controller base. With this change incoming api requests
are verified based on an api token, and also the source IP

This was a simple change since we already were using and passing an auth token :P
